### PR TITLE
:sparkles: Add route to fetch User stats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "A microservice for handling user account actions in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/UserStats/UserStatStore.ts
+++ b/src/UserStats/UserStatStore.ts
@@ -1,0 +1,42 @@
+import { Db } from 'mongodb';
+import { COLLECTIONS } from '../drivers/MongoDriver';
+import { UserStatDatastore, UserStats } from './UserStatsInteractor';
+
+export class UserStatStore implements UserStatDatastore {
+  constructor(private db: Db) {}
+
+  /**
+   * Fetches stats for User accounts
+   *
+   * @param {{ query: any }} params
+   * @returns {Promise<UserStats>}
+   * @memberof UserStatStore
+   */
+  async fetchStats(params: { query: any }): Promise<UserStats> {
+    const statCursor = await this.db
+      .collection(COLLECTIONS.User.name)
+      .aggregate([
+        { $match: params.query },
+        {
+          $group: {
+            _id: 1,
+            count: { $sum: 1 },
+            organizations: { $addToSet: '$organization' }
+          }
+        }
+      ]);
+    const statsArr: {
+      _id: string;
+      count: number;
+      organizations: string[];
+    }[] = await statCursor.toArray();
+    let stats: UserStats;
+    if (statsArr && statsArr.length) {
+      stats = {
+        accounts: statsArr[0].count,
+        organizations: statsArr[0].organizations.length
+      };
+    }
+    return stats;
+  }
+}

--- a/src/UserStats/UserStatsInteractor.ts
+++ b/src/UserStats/UserStatsInteractor.ts
@@ -1,0 +1,15 @@
+export interface UserStats {
+  accounts: number;
+  organizations: number;
+}
+export interface UserStatDatastore {
+  fetchStats(params: { query: any }): Promise<UserStats>;
+}
+
+export async function getStats(params: {
+  dataStore: UserStatDatastore;
+  query: any;
+}): Promise<UserStats> {
+  const stats = await params.dataStore.fetchStats({ query: params.query });
+  return stats;
+}

--- a/src/UserStats/UserStatsRouteHandler.ts
+++ b/src/UserStats/UserStatsRouteHandler.ts
@@ -22,6 +22,6 @@ export function initialize({ dataStore }: { dataStore: DataStore }) {
     }
   };
 
-  router.route('').get(getStats);
+  router.get(getStats);
   return router;
 }

--- a/src/UserStats/UserStatsRouteHandler.ts
+++ b/src/UserStats/UserStatsRouteHandler.ts
@@ -1,0 +1,27 @@
+import * as UserStatsInteractor from './UserStatsInteractor';
+import { Request, Response, Router } from 'express';
+import { DataStore } from '../interfaces/DataStore';
+
+/**
+ * Initializes an express router with endpoints to get stats for a User
+ */
+export function initialize({ dataStore }: { dataStore: DataStore }) {
+  const router: Router = Router();
+  const getStats = async (req: Request, res: Response) => {
+    try {
+      const query = req.query;
+      const stats = await UserStatsInteractor.getStats({
+        dataStore,
+        query
+      });
+
+      res.status(200).send(stats);
+    } catch (e) {
+      console.error(e);
+      res.status(500).send(e);
+    }
+  };
+
+  router.route('').get(getStats);
+  return router;
+}

--- a/src/drivers/RouteHandler.ts
+++ b/src/drivers/RouteHandler.ts
@@ -12,6 +12,7 @@ import { ACCOUNT_ACTIONS } from '../interfaces/Mailer.defaults';
 import { REDIRECT_ROUTES } from '../environment/routes';
 import { User } from '@cyber4all/clark-entity';
 import * as request from 'request';
+import * as UserStatsRouteHandler from '../UserStats/UserStatsRouteHandler';
 const version = require('../../package.json').version;
 
 export default class RouteHandler {
@@ -295,5 +296,10 @@ export default class RouteHandler {
           .sendOperationError(`Could not validate captcha. Error: ${e}`);
       }
     });
+
+    router.use(
+      '/users/stats',
+      UserStatsRouteHandler.initialize({ dataStore: this.dataStore })
+    );
   }
 }

--- a/src/interfaces/DataStore.ts
+++ b/src/interfaces/DataStore.ts
@@ -1,8 +1,9 @@
 import { User } from '@cyber4all/clark-entity';
 import { OTACode } from '../drivers/OTACodeManager';
 import { UserQuery } from './Query';
+import { UserStatDatastore } from '../UserStats/UserStatsInteractor';
 
-export interface DataStore {
+export interface DataStore extends UserStatDatastore {
   connect(dbURI: string): Promise<void>;
   disconnect(): void;
   identifierInUse(username: string): Promise<boolean>;


### PR DESCRIPTION
Added a route /users/stats to fetch the following properties about the users collection:
- accounts (number of accounts)
- organizations (number of organizations)

This route accepts query parameters for `username`, `email`, `name`, and `organization`.