### PR TITLE
:bug: Fix username not being lower cased on register

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A microservice for handling user account actions in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/interactors/AuthenticationInteractor.ts
+++ b/src/interactors/AuthenticationInteractor.ts
@@ -63,10 +63,9 @@ export async function register(
   user: AuthUser
 ): Promise<{ token: string; user: User }> {
   try {
-    const username = sanitizeText(user.username);
     if (
-      isValidUsername(username) &&
-      !(await datastore.identifierInUse(username))
+      isValidUsername(user.username) &&
+      !(await datastore.identifierInUse(user.username))
     ) {
       const pwdhash = await hasher.hash(user.password);
       user.password = pwdhash;

--- a/src/types/auth-user.ts
+++ b/src/types/auth-user.ts
@@ -16,7 +16,8 @@ export class AuthUser extends User {
     this._accessGroups = accessGroups;
   }
   constructor(user: Partial<AuthUser>) {
-    super(user);
+    const username = user.username ? user.username.toLowerCase().trim() : '';
+    super({ ...user, username });
     this._password = user.password || '';
     this._accessGroups = user.accessGroups || [];
   }


### PR DESCRIPTION
**Issue**
Users' usernames were not being properly lower cased on registration causing data inconsistencies.

**Solution**
Add logic to lowercase and trim usernames in the `AuthUser` class.