### PR TITLE
remove id assignment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A microservice for handling user account actions in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/interactors/AdminUserInteractor.ts
+++ b/src/interactors/AdminUserInteractor.ts
@@ -22,7 +22,6 @@ export class AdminUserInteractor {
       const response = await dataStore.searchUsers(query);
       const users = await Promise.all(
         response.users.map(async user => {
-          user.id = await dataStore.findUser(user.username);
           user.password = undefined;
           return user;
         })


### PR DESCRIPTION
The reassignment of id in the AdminUserInteractor was triggering an entity error. User ids are still sent to the client without this line. 