### PR TITLE
return object with accessGroups on login

### DIFF
--- a/src/drivers/RouteHandler.ts
+++ b/src/drivers/RouteHandler.ts
@@ -127,7 +127,7 @@ export default class RouteHandler {
           responder.invalidLogin();
         } else if (typeof userPayload !== 'boolean') {
           responder.setCookie('presence', userPayload.token);
-          responder.sendUser(userPayload.user.toPlainObject());
+          responder.sendUser(userPayload.user);
         }
       } catch (e) {
         responder.sendOperationError(e);

--- a/src/interactors/AuthenticationInteractor.ts
+++ b/src/interactors/AuthenticationInteractor.ts
@@ -21,7 +21,7 @@ export async function login(
   hasher: HashInterface,
   username: string,
   password: string
-): Promise<boolean | { token: string; user: User }> {
+): Promise<boolean | { token: string; user: any }> {
   try {
     let id;
     let authenticated = false;
@@ -38,7 +38,15 @@ export async function login(
 
     if (authenticated) {
       const token = TokenManager.generateToken(user);
-      return { token, user: new User(user) };
+      const userResponse = {
+        username: user.username,
+        name: user.name,
+        email: user.email,
+        organization: user.organization,
+        emailVerified: user.emailVerified,
+        accessGroups: user.accessGroups
+      };
+      return {token, user: userResponse};
     }
     return authenticated;
   } catch (e) {


### PR DESCRIPTION
On login, return object with accessGroups to the client. This prevents inconsistencies with user object that exists on token refresh.