### PR TITLE
Fix member removal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "A microservice for handling user account actions in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/UserMetaRetriever/AuthorizationManager.ts
+++ b/src/UserMetaRetriever/AuthorizationManager.ts
@@ -30,7 +30,7 @@ export function requesterIsAdmin(userToken: UserToken): boolean {
  * @export
  * @param {boolean[]} authorizationCases [List of boolean values from the result of an authorization check]
  */
-export function authorizeRequest(authorizationCases: boolean[]) {
+export function authorizeRequest(authorizationCases: boolean[]): never | void {
   if (!authorizationCases.includes(true)) {
     throw new ResourceError(
       'Invalid access',

--- a/src/collection-role/AuthManager.ts
+++ b/src/collection-role/AuthManager.ts
@@ -66,10 +66,10 @@ export function verifyCollectionName(
  * @property { string } collection name of a collection
  * @returns { boolean }
  */
-export function verifyAssignAccess(
+export function hasRoleModAccess(
     role: string,
     user: UserToken,
-    collection: string,
+  collection: string
 ): boolean {
   switch (role) {
     case ROLES.CURATOR:

--- a/src/collection-role/AuthManager.ts
+++ b/src/collection-role/AuthManager.ts
@@ -74,7 +74,7 @@ export function verifyCollectionName(
  * @property { string } collection name of a collection
  * @returns { boolean }
  */
-export function hasRoleModAccess(
+export function hasRoleModificationAccess(
   role: string,
   user: UserToken,
   collection: string

--- a/src/collection-role/AuthManager.ts
+++ b/src/collection-role/AuthManager.ts
@@ -1,6 +1,11 @@
 import { UserToken } from '../types/user-token';
 import { UserDocument } from '../types/user-document';
-import { ServiceError, ServiceErrorReason } from '../Error';
+import {
+  ServiceError,
+  ServiceErrorReason,
+  ResourceError,
+  ResourceErrorReason
+} from '../Error';
 
 const ROLES = {
   ADMIN: 'admin',
@@ -123,4 +128,19 @@ export function isAdmin(user: UserToken): boolean {
  */
 function isCurator(user: UserToken, collection: string): boolean {
   return user.accessGroups.includes(`${ROLES.CURATOR}@${collection}`);
+}
+
+/**
+ * Checks if request should be authorized by checking if `authorizationCases` contains `true`.
+ *
+ * @export
+ * @param {boolean[]} authorizationCases [List of boolean values from the result of an authorization check]
+ */
+export function authorizeRequest(authorizationCases: boolean[]): never | void {
+  if (!authorizationCases.includes(true)) {
+    throw new ResourceError(
+      'Invalid access',
+      ResourceErrorReason.INVALID_ACCESS
+    );
+  }
 }

--- a/src/collection-role/Interactor.spec.ts
+++ b/src/collection-role/Interactor.spec.ts
@@ -1,4 +1,11 @@
-import { Assign, Edit, Remove, fetchReviewers, fetchCurators, fetchMembers } from '../collection-role/Interactor';
+import {
+  Assign,
+  Edit,
+  removeRole,
+  fetchReviewers,
+  fetchCurators,
+  fetchMembers
+} from '../collection-role/Interactor';
 import MockDriver from '../drivers/MockDriver';
 import { COLLECTION_ROLE_MOCK_OBJECTS } from './MocksObjects';
 import { MOCK_OBJECTS } from '../tests/mocks';
@@ -8,284 +15,337 @@ const driver = new MockDriver();
 describe('Assign.start', () => {
   it('allows an admin assign a curator role to a user who is not a member of the collection', async () => {
     expect.assertions(1);
-    await expect(Assign.start(
+    await expect(
+      Assign.start(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_ADMIN,
         COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_C5,
         MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_CURATOR,
-    )).resolves.toBe(undefined);
+        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_CURATOR
+      )
+    ).resolves.toBe(undefined);
   });
   it('allows an admin assign a reviewer role to a user who is not a member of the collection', async () => {
     expect.assertions(1);
-    await expect(Assign.start(
+    await expect(
+      Assign.start(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_ADMIN,
         COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_C5,
         MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER,
-    )).resolves.toBe(undefined);
+        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER
+      )
+    ).resolves.toBe(undefined);
   });
   it('allows an admin assign a curator role to a user who is not a member of the collection', async () => {
     expect.assertions(1);
-    await expect(Assign.start(
+    await expect(
+      Assign.start(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_ADMIN,
         COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_SECJ,
         MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_CURATOR,
-    )).resolves.toBe(undefined);
+        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_CURATOR
+      )
+    ).resolves.toBe(undefined);
   });
   it('allows an admin assign a reviewer role to a user who is not a member of the collection', async () => {
     expect.assertions(1);
-    await expect(Assign.start(
+    await expect(
+      Assign.start(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_ADMIN,
         COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_SECJ,
         MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER,
-    )).resolves.toBe(undefined);
+        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER
+      )
+    ).resolves.toBe(undefined);
   });
   it('allows an admin cannot assign curator role to a user who is already a member of the collection', async () => {
     expect.assertions(1);
-    await expect(Assign.start(
+    await expect(
+      Assign.start(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_ADMIN,
         COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP,
         MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_CURATOR,
-    )).rejects.toBeInstanceOf(ResourceError);
+        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_CURATOR
+      )
+    ).rejects.toBeInstanceOf(ResourceError);
   });
   it('prevents an admin from assigning a reviewer role to a user who is already a member of the collection', async () => {
     expect.assertions(1);
-    await expect(Assign.start(
+    await expect(
+      Assign.start(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_ADMIN,
         COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP,
         MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER,
-    )).rejects.toBeInstanceOf(ResourceError);
+        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER
+      )
+    ).rejects.toBeInstanceOf(ResourceError);
   });
   it('allows a curator to assign a reviewer role to a user who is not a member of the collection', async () => {
     expect.assertions(1);
-    await expect(Assign.start(
+    await expect(
+      Assign.start(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_CURATOR_C5,
         COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_C5,
         MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER,
-    )).resolves.toBe(undefined);
+        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER
+      )
+    ).resolves.toBe(undefined);
   });
   it('prevents a curator from assigning a curator role to a user who is not a member of the collection', async () => {
     expect.assertions(1);
-    await expect(Assign.start(
+    await expect(
+      Assign.start(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_CURATOR_C5,
         COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_C5,
         MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_CURATOR,
-    )).rejects.toBeInstanceOf(ResourceError);
+        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_CURATOR
+      )
+    ).rejects.toBeInstanceOf(ResourceError);
   });
   it('prevents a curator from assigning a curator role to a user who is already a member of the collection', async () => {
     expect.assertions(1);
-    await expect(Assign.start(
+    await expect(
+      Assign.start(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_CURATOR_NCCP,
         COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_C5,
         MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_CURATOR,
-    )).rejects.toBeInstanceOf(ResourceError);
+        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_CURATOR
+      )
+    ).rejects.toBeInstanceOf(ResourceError);
   });
   it('prevents a curator from assigning a reviewer role to a user who is already a member of the collection', async () => {
     expect.assertions(1);
-    await expect(Assign.start(
+    await expect(
+      Assign.start(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_CURATOR_NCCP,
         COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_C5,
         MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER,
-    )).rejects.toBeInstanceOf(ResourceError);
+        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER
+      )
+    ).rejects.toBeInstanceOf(ResourceError);
   });
   it('prevents a curator from assigning a curator role to a user who is not a member of a different collection', async () => {
     expect.assertions(1);
-    await expect(Assign.start(
+    await expect(
+      Assign.start(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_CURATOR_NCCP,
         COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_C5,
         MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_CURATOR,
-    )).rejects.toBeInstanceOf(ResourceError);
+        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_CURATOR
+      )
+    ).rejects.toBeInstanceOf(ResourceError);
   });
   it('prevents a curator from assigning a reviewer role to a user who is not a member of a different collection', async () => {
     expect.assertions(1);
-    await expect(Assign.start(
+    await expect(
+      Assign.start(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_CURATOR_NCCP,
         COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_C5,
         MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER,
-    )).rejects.toBeInstanceOf(ResourceError);
+        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER
+      )
+    ).rejects.toBeInstanceOf(ResourceError);
   });
   it('prevents a curator from assigning a curator role to a user who is a member of a different collection', async () => {
     expect.assertions(1);
-    await expect(Assign.start(
+    await expect(
+      Assign.start(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_CURATOR_C5,
         COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP,
         MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_CURATOR,
-    )).rejects.toBeInstanceOf(ResourceError);
+        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_CURATOR
+      )
+    ).rejects.toBeInstanceOf(ResourceError);
   });
   it('prevents a curator from assigning a reviewer role to a user who is a member of a different collection', async () => {
     expect.assertions(1);
-    await expect(Assign.start(
+    await expect(
+      Assign.start(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_CURATOR_C5,
         COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP,
         MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER,
-    )).rejects.toBeInstanceOf(ResourceError);
+        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER
+      )
+    ).rejects.toBeInstanceOf(ResourceError);
   });
 });
-
 
 describe('Edit.start', () => {
   it('allows an admin to give a curator reviewer access within the same collection', async () => {
     expect.assertions(1);
-    await expect(Edit.start(
+    await expect(
+      Edit.start(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_ADMIN,
         COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP,
         MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER,
-    )).resolves.toBe(undefined);
+        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER
+      )
+    ).resolves.toBe(undefined);
   });
   it('prevents an admin from giving a curator reviewer access for a different collection', async () => {
     expect.assertions(1);
-    await expect(Edit.start(
+    await expect(
+      Edit.start(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_ADMIN,
         COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_C5,
         MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER,
-    )).rejects.toBeInstanceOf(ResourceError);
+        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER
+      )
+    ).rejects.toBeInstanceOf(ResourceError);
   });
   it('curator - can give a curator reviewer access within the same collection', async () => {
     expect.assertions(1);
-    await expect(Edit.start(
+    await expect(
+      Edit.start(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_CURATOR_NCCP,
         COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP,
         MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER,
-    )).resolves.toBe(undefined);
+        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER
+      )
+    ).resolves.toBe(undefined);
   });
   it('curator - cannot give a curator reviewer access for a different collection', async () => {
     expect.assertions(1);
-    await expect(Edit.start(
+    await expect(
+      Edit.start(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_CURATOR_NCCP,
         COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_C5,
         MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER,
-    )).rejects.toBeInstanceOf(ResourceError);
+        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_REVIEWER
+      )
+    ).rejects.toBeInstanceOf(ResourceError);
   });
 });
 
-describe('Remove.start', () => {
+describe('removeRole', () => {
   it('allows an admin to remove a curator role from a user', async () => {
     expect.assertions(1);
-    await expect(Remove.start(
-        driver,
-        COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_ADMIN,
-        COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP,
-        MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_CURATOR,
-    )).resolves.toBe(undefined);
+    await expect(
+      removeRole({
+        dataStore: driver,
+        requester: COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_ADMIN,
+        collection: COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP,
+        userId: MOCK_OBJECTS.USER_ID
+      })
+    ).resolves.toBe(undefined);
   });
   it('prevents an admin from removing a role that does not exist on user', async () => {
     expect.assertions(1);
-    await expect(Remove.start(
-        driver,
-        COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_ADMIN,
-        COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_C5,
-        MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_CURATOR,
-    )).rejects.toBeInstanceOf(ResourceError);
+    MOCK_OBJECTS.ROLE = null;
+    await expect(
+      removeRole({
+        dataStore: driver,
+        requester: COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_ADMIN,
+        collection: COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_C5,
+        userId: MOCK_OBJECTS.USER_ID
+      })
+    ).rejects.toBeInstanceOf(ResourceError);
   });
   it('prevents a curator from removing a curator role from a user', async () => {
     expect.assertions(1);
-    await expect(Remove.start(
-        driver,
-        COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_CURATOR_NCCP,
-        COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP,
-        MOCK_OBJECTS.USER_ID,
-        COLLECTION_ROLE_MOCK_OBJECTS.ROLE_CURATOR,
-    )).rejects.toBeInstanceOf(ResourceError);
+    await expect(
+      removeRole({
+        dataStore: driver,
+        requester: COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_CURATOR_NCCP,
+        collection: COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP,
+        userId: MOCK_OBJECTS.USER_ID
+      })
+    ).rejects.toBeInstanceOf(ResourceError);
   });
 });
 
 describe('fetchReviewers', () => {
   it('allows an admin to fetch all reviewers for a colleciton', async () => {
     expect.assertions(1);
-    await expect(fetchReviewers(
+    await expect(
+      fetchReviewers(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_ADMIN,
-        COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP,
-    )).resolves.toBeInstanceOf(Array);
+        COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP
+      )
+    ).resolves.toBeInstanceOf(Array);
   });
   it('allows a curator to fetch all reviewers for a colleciton', async () => {
     expect.assertions(1);
-    await expect(fetchReviewers(
+    await expect(
+      fetchReviewers(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_CURATOR_NCCP,
-        COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP,
-    )).resolves.toBeInstanceOf(Array);
+        COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP
+      )
+    ).resolves.toBeInstanceOf(Array);
   });
   it('prevents a curator from fetching all reviewers for a different collection', async () => {
     expect.assertions(1);
-    await expect(fetchReviewers(
+    await expect(
+      fetchReviewers(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_CURATOR_NCCP,
-        COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_C5,
-    )).rejects.toBeInstanceOf(ResourceError);
+        COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_C5
+      )
+    ).rejects.toBeInstanceOf(ResourceError);
   });
 });
 
 describe('fetchCurators', () => {
   it('allows an admin to fetch all curators for a colleciton', async () => {
     expect.assertions(1);
-    await expect(fetchCurators(
+    await expect(
+      fetchCurators(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_ADMIN,
-        COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP,
-    )).resolves.toBeInstanceOf(Array);
+        COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP
+      )
+    ).resolves.toBeInstanceOf(Array);
   });
   it('prevents a curator from fetching all curators for a colleciton', async () => {
     expect.assertions(1);
-    await expect(fetchCurators(
+    await expect(
+      fetchCurators(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_CURATOR_NCCP,
-        COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP,
-    )).rejects.toBeInstanceOf(ResourceError);
+        COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP
+      )
+    ).rejects.toBeInstanceOf(ResourceError);
   });
 });
 
 describe('fetchMembers', () => {
   it('allows an admin to fetch all members for a colleciton', async () => {
     expect.assertions(1);
-    await expect(fetchMembers(
+    await expect(
+      fetchMembers(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_ADMIN,
-        COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP,
-    )).resolves.toBeInstanceOf(Array);
+        COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP
+      )
+    ).resolves.toBeInstanceOf(Array);
   });
   it('prevents a curator from fetching all members for a colleciton', async () => {
     expect.assertions(1);
-    await expect(fetchMembers(
+    await expect(
+      fetchMembers(
         driver,
         COLLECTION_ROLE_MOCK_OBJECTS.USER_TOKEN_CURATOR_NCCP,
-        COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP,
-    )).rejects.toBeInstanceOf(ResourceError);
+        COLLECTION_ROLE_MOCK_OBJECTS.COLLECTION_NCCP
+      )
+    ).rejects.toBeInstanceOf(ResourceError);
   });
 });

--- a/src/collection-role/Interactor.ts
+++ b/src/collection-role/Interactor.ts
@@ -1,12 +1,13 @@
 import { UserToken } from '../types/user-token';
 import { DataStore } from '../interfaces/interfaces';
 import {
-  verifyAssignAccess,
+  hasRoleModAccess,
   verifyCollectionName,
   isCollectionMember,
   hasAccessGroup,
   isAdmin,
   verifyReadReviewerAccess,
+  authorizeRequest
 } from './AuthManager';
 import { ResourceError, ResourceErrorReason, ServiceError, ServiceErrorReason } from '../Error';
 import { UserDocument } from '../types/user-document';
@@ -39,7 +40,7 @@ abstract class RoleActions {
    * @returns { Promise<void> }
    */
   async modifyCollectionRole(): Promise<void> {
-    if (verifyAssignAccess(this.role, this.user, this.collection)) {
+    authorizeRequest([hasRoleModAccess(this.role, this.user, this.collection)]);
       const userDocument = await this.dataStore.findUserById(this.userId);
       if (userDocument) {
         const formattedAccessGroup = `${this.role}@${this.collection}`;

--- a/src/collection-role/Interactor.ts
+++ b/src/collection-role/Interactor.ts
@@ -285,3 +285,41 @@ export async function fetchMembers(
   }
   throw new ResourceError('Invalid Access', ResourceErrorReason.INVALID_ACCESS);
 }
+
+/**
+ * Validates all required values are provided for request
+ *
+ * @param {any[]} params
+ * @param {string[]} [mustProvide]
+ * @returns {(void | never)}
+ */
+function validateRequestParams({
+  params,
+  mustProvide
+}: {
+  params: any[];
+  mustProvide?: string[];
+}): void | never {
+  const values = [...params].map(val => {
+    if (typeof val === 'string') {
+      val = val.trim();
+    }
+    return val;
+  });
+  if (
+    values.includes(null) ||
+    values.includes('null') ||
+    values.includes(undefined) ||
+    values.includes('undefined') ||
+    values.includes('')
+  ) {
+    const multipleParams = mustProvide.length > 1;
+    let message = 'Invalid parameters provided';
+    if (Array.isArray(mustProvide)) {
+      message = `Must provide ${multipleParams ? '' : 'a'} valid value${
+        multipleParams ? 's' : ''
+      } for ${mustProvide}`;
+    }
+    throw new ResourceError(message, ResourceErrorReason.BAD_REQUEST);
+  }
+}

--- a/src/collection-role/Interactor.ts
+++ b/src/collection-role/Interactor.ts
@@ -40,27 +40,18 @@ abstract class RoleActions {
    * @returns { Promise<void> }
    */
   async modifyCollectionRole(): Promise<void> {
+    validateRequestParams({
+      params: [this.userId, this.role, this.collection],
+      mustProvide: ['id', 'role', 'collection']
+    });
     authorizeRequest([hasRoleModAccess(this.role, this.user, this.collection)]);
       const userDocument = await this.dataStore.findUserById(this.userId);
-      if (userDocument) {
-        const formattedAccessGroup = `${this.role}@${this.collection}`;
-        await this.performRoleAction(
-          formattedAccessGroup,
-          userDocument,
-        );
-      } else {
-        throw new ResourceError(
-          'User Not Found',
-          ResourceErrorReason.NOT_FOUND
-        );
-      }
-    } else {
-      throw new ResourceError(
-        'Invalid Access',
-        ResourceErrorReason.INVALID_ACCESS
-      );
+    if (!userDocument) {
+      throw new ResourceError('User Not Found', ResourceErrorReason.NOT_FOUND);
     }
-  }
+        const formattedAccessGroup = `${this.role}@${this.collection}`;
+    await this.performRoleAction(formattedAccessGroup, userDocument);
+      }
   abstract performRoleAction(
     formattedAccessGroup: string,
     userDocument: UserDocument,

--- a/src/collection-role/Interactor.ts
+++ b/src/collection-role/Interactor.ts
@@ -1,7 +1,7 @@
 import { UserToken } from '../types/user-token';
 import { DataStore } from '../interfaces/interfaces';
 import {
-  hasRoleModAccess,
+  hasRoleModificationAccess,
   isCollectionMember,
   isAdmin,
   verifyReadReviewerAccess,
@@ -46,7 +46,7 @@ abstract class RoleActions {
       params: [this.userId, this.role, this.collection],
       mustProvide: ['id', 'role', 'collection']
     });
-    authorizeRequest([hasRoleModAccess(this.role, this.user, this.collection)]);
+    authorizeRequest([hasRoleModificationAccess(this.role, this.user, this.collection)]);
       const userDocument = await this.dataStore.findUserById(this.userId);
     if (!userDocument) {
       throw new ResourceError('User Not Found', ResourceErrorReason.NOT_FOUND);
@@ -194,7 +194,7 @@ export async function removeRole({
       );
     }
     const [role] = privilege.split('@');
-    authorizeRequest([hasRoleModAccess(role, requester, collection)]);
+    authorizeRequest([hasRoleModificationAccess(role, requester, collection)]);
     await dataStore.removeAccessGroup(userId, privilege);
   } catch (e) {
     handleError(e);

--- a/src/collection-role/Interactor.ts
+++ b/src/collection-role/Interactor.ts
@@ -2,9 +2,7 @@ import { UserToken } from '../types/user-token';
 import { DataStore } from '../interfaces/interfaces';
 import {
   hasRoleModAccess,
-  verifyCollectionName,
   isCollectionMember,
-  hasAccessGroup,
   isAdmin,
   verifyReadReviewerAccess,
   authorizeRequest
@@ -12,8 +10,6 @@ import {
 import {
   ResourceError,
   ResourceErrorReason,
-  ServiceError,
-  ServiceErrorReason,
   handleError
 } from '../Error';
 import { UserDocument } from '../types/user-document';

--- a/src/collection-role/RouteHandler.ts
+++ b/src/collection-role/RouteHandler.ts
@@ -1,7 +1,14 @@
 import { Router, Request, Response } from 'express';
-import { fetchReviewers, Assign, Edit, Remove, fetchCurators, fetchMembers } from './Interactor';
+import {
+  fetchReviewers,
+  Assign,
+  Edit,
+  fetchCurators,
+  fetchMembers,
+  removeRole
+} from './Interactor';
 import { DataStore } from '../interfaces/DataStore';
-import { mapErrorToResponseData, ResourceError, ResourceErrorReason } from '../Error';
+import { mapErrorToResponseData } from '../Error';
 import { UserToken } from '../types/user-token';
 
 export function initializePrivate({ dataStore }: { dataStore: DataStore }) {
@@ -17,39 +24,30 @@ export function initializePrivate({ dataStore }: { dataStore: DataStore }) {
     REVIEWER: 'reviewer',
   };
 
-  const modifyCollectionRole = async (req: Request, res: Response, action: string) => {
+  const modifyCollectionRole = async (
+    req: Request,
+    res: Response,
+    action: string
+  ) => {
     try {
-      const user: UserToken = req.user;
+      const userToken: UserToken = req.user;
       const role: string = req.body.role;
       const collection: string = req.params.collectionName;
       const userId: string = req.params.memberId;
       switch (action) {
         case ROLE_ACTIONS.ASSIGN:
-          await Assign.start(
-            dataStore,
-            user,
-            collection,
-            userId,
-            role,
-          );
+          await Assign.start(dataStore, userToken, collection, userId, role);
           break;
         case ROLE_ACTIONS.EDIT:
-          await Edit.start(
-            dataStore,
-            user,
-            collection,
-            userId,
-            role,
-          );
+          await Edit.start(dataStore, userToken, collection, userId, role);
           break;
         case ROLE_ACTIONS.REMOVE:
-          await Remove.start(
+          await removeRole({
             dataStore,
-            user,
-            collection,
             userId,
-            role,
-          );
+            collection,
+            requester: userToken
+          });
           break;
       }
       res.sendStatus(200);

--- a/src/collection-role/RouteHandler.ts
+++ b/src/collection-role/RouteHandler.ts
@@ -21,12 +21,6 @@ export function initializePrivate({ dataStore }: { dataStore: DataStore }) {
     try {
       const user: UserToken = req.user;
       const role: string = req.body.role;
-      if (!role) {
-        throw new ResourceError(
-          'Must provide a role',
-          ResourceErrorReason.BAD_REQUEST
-        );
-      }
       const collection: string = req.params.collectionName;
       const userId: string = req.params.memberId;
       switch (action) {

--- a/src/drivers/MockDriver.ts
+++ b/src/drivers/MockDriver.ts
@@ -7,6 +7,12 @@ import { UserStats } from '../UserStats/UserStatsInteractor';
 import { UserDocument } from '../types/user-document';
 
 export default class MockDriver implements DataStore {
+  fetchUserCollectionRole(params: {
+    userId: string;
+    collection: string;
+  }): Promise<string> {
+    return Promise.resolve(MOCK_OBJECTS.ROLE);
+  }
 
   connect(dbURI: string): Promise<void> {
     return Promise.resolve();
@@ -52,10 +58,11 @@ export default class MockDriver implements DataStore {
     return Promise.resolve();
   }
 
-  searchUsers(
-    query: UserQuery
-  ): Promise<{ users: any[]; total: number; }> {
-    return Promise.resolve({ users: [MOCK_OBJECTS.USER], total: MOCK_OBJECTS.SEARCH_COUNT });
+  searchUsers(query: UserQuery): Promise<{ users: any[]; total: number }> {
+    return Promise.resolve({
+      users: [MOCK_OBJECTS.USER],
+      total: MOCK_OBJECTS.SEARCH_COUNT
+    });
   }
 
   fetchReviewers(collection: string): Promise<any[]> {
@@ -74,7 +81,10 @@ export default class MockDriver implements DataStore {
     return Promise.resolve(MOCK_OBJECTS.MODIFY_ROLE_USER);
   }
 
-  assignAccessGroup(userId: string, formattedAccessGroup: string): Promise<void> {
+  assignAccessGroup(
+    userId: string,
+    formattedAccessGroup: string
+  ): Promise<void> {
     return Promise.resolve();
   }
 
@@ -86,11 +96,14 @@ export default class MockDriver implements DataStore {
     return Promise.resolve();
   }
 
-  removeAccessGroup(userId: string, formattedAccessGroup: string): Promise<void> {
+  removeAccessGroup(
+    userId: string,
+    formattedAccessGroup: string
+  ): Promise<void> {
     return Promise.resolve();
   }
 
-  fetchStats(params: { query: any; }): Promise<UserStats> {
+  fetchStats(params: { query: any }): Promise<UserStats> {
     return Promise.resolve(MOCK_OBJECTS.USER_STATS);
   }
 

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -49,6 +49,39 @@ export default class MongoDriver implements DataStore {
   }
 
   /**
+   * Fetches user's role for a collection
+   *
+   * @param {string} userId [Id of the user to fetch collection role for]
+   * @param {string} collection [Name of the collection to find role for]
+   * @returns {Promise<string>}
+   * @memberof MongoDriver
+   */
+  async fetchUserCollectionRole({
+    userId,
+    collection
+  }: {
+    userId: string;
+    collection: string;
+  }): Promise<string> {
+    const doc = await this.db
+      .collection(COLLECTIONS.USERS)
+      .findOne<{ accessGroups: string[] }>(
+        { _id: userId, accessGroups: { $regex: new RegExp(collection, 'ig') } },
+        {
+          projection: {
+            _id: 0,
+            'accessGroups.$': 1
+          }
+        }
+      );
+    if (doc) {
+      return doc.accessGroups[0];
+    }
+
+    return null;
+  }
+
+  /**
    * Fetches Stats for User Accounts
    *
    * @param {{ query: any }} params

--- a/src/interfaces/DataStore.ts
+++ b/src/interfaces/DataStore.ts
@@ -20,6 +20,7 @@ export interface DataStore extends UserStatDatastore {
   fetchCurators(collection: string): Promise<any[]>;
   fetchCollectionMembers(collection: string): Promise<any[]>;
   findUserById(userId: string): Promise<UserDocument>;
+  fetchUserCollectionRole(params: {userId: string, collection: string}): Promise<string>;
   assignAccessGroup(userId: string, formattedAccessGroup: string): Promise<void>;
   editAccessGroup(
     userId: string,


### PR DESCRIPTION
This PR fixes the issue with removing a member from a collection due the `role` parameter not being sent up by the client. This presence of this parameter was being required by the remove function although it should not have been since a user can only have one role within a collection.