### PR TITLE
Fix bug where users with no accessGroups property causes route to add privilege to error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A microservice for handling user account actions in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/collection-role/AuthManager.ts
+++ b/src/collection-role/AuthManager.ts
@@ -16,7 +16,10 @@ const ROLES = {
  * @property { UserDocument } user user object fetched from database
  * @returns { boolean }
  */
-export function hasAccessGroup(formattedAccessGroup: string, user: UserDocument): boolean {
+export function hasAccessGroup(
+  formattedAccessGroup: string,
+  user: UserDocument
+): boolean {
   return user.accessGroups.includes(formattedAccessGroup);
 }
 
@@ -28,8 +31,13 @@ export function hasAccessGroup(formattedAccessGroup: string, user: UserDocument)
  * @property { UserDocument } user user object fetched from database
  * @returns { boolean }
  */
-export function isCollectionMember(collection: string, user: UserDocument): boolean {
-  const filteredAccessGroups = user.accessGroups.filter(group => group.includes('@'));
+export function isCollectionMember(
+  collection: string,
+  user: UserDocument
+): boolean {
+  const filteredAccessGroups = user.accessGroups
+    ? user.accessGroups.filter(group => group.includes('@'))
+    : [];
   if (!(filteredAccessGroups.length > 0)) {
     return false;
   }
@@ -46,9 +54,9 @@ export function isCollectionMember(collection: string, user: UserDocument): bool
  * @returns { boolean }
  */
 export function verifyCollectionName(
-    user: UserToken,
-    collection: string,
-  ): boolean {
+  user: UserToken,
+  collection: string
+): boolean {
   return user.accessGroups.includes(`${ROLES.CURATOR}@${collection}`);
 }
 
@@ -62,9 +70,9 @@ export function verifyCollectionName(
  * @returns { boolean }
  */
 export function verifyAssignAccess(
-    role: string,
-    user: UserToken,
-    collection: string,
+  role: string,
+  user: UserToken,
+  collection: string
 ): boolean {
   switch (role) {
     case ROLES.CURATOR:
@@ -86,7 +94,7 @@ export function verifyAssignAccess(
  */
 export function verifyReadReviewerAccess(
   user: UserToken,
-  collection: string,
+  collection: string
 ): boolean {
   return isAdmin(user) || isCurator(user, collection);
 }
@@ -98,7 +106,7 @@ export function verifyReadReviewerAccess(
  * @returns { string }
  */
 function parseCollection(accessGroup: string): string {
-  if (!(accessGroup.includes('@'))) {
+  if (!accessGroup.includes('@')) {
     throw new ServiceError(ServiceErrorReason.INTERNAL);
   }
   return accessGroup.split('@')[1];


### PR DESCRIPTION
This PR fixes a bug wherein a user with no accessGroups property can't have their privileges modified. Most of the changes below are formatting changes, the only bit that was changed is the first line of the `isCollectionMember` function.