### PR TITLE
Encode user id into token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "A microservice for handling user account actions in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/UserMetaRetriever/tests/MockStore.ts
+++ b/src/UserMetaRetriever/tests/MockStore.ts
@@ -2,6 +2,7 @@ import { UserToken } from '../typings';
 
 export const userId = '123';
 export const userToken: UserToken = {
+  id: '123',
   name: '',
   username: 'testUser',
   accessGroups: ['admin'],

--- a/src/collection-role/MocksObjects.ts
+++ b/src/collection-role/MocksObjects.ts
@@ -5,27 +5,30 @@ export const COLLECTION_ROLE_MOCK_OBJECTS = {
   ROLE_CURATOR: 'curator',
   ROLE_REVIEWER: 'reviewer',
   USER_TOKEN_ADMIN: {
+    id: '123',
     username: 'admin',
     name: 'unit test',
     email: 'test@admin.com',
     organization: 'admin',
     emailVerified: false,
-    accessGroups: ['admin'],
+    accessGroups: ['admin']
   },
   USER_TOKEN_CURATOR_C5: {
+    id: '456',
     username: 'curator',
     name: 'unit test',
     email: 'test@curator.com',
     organization: 'curator',
     emailVerified: false,
-    accessGroups: ['curator@c5'],
+    accessGroups: ['curator@c5']
   },
   USER_TOKEN_CURATOR_NCCP: {
+    id: '789',
     username: 'curator',
     name: 'unit test',
     email: 'test@curator.com',
     organization: 'curator',
     emailVerified: false,
-    accessGroups: ['curator@nccp'],
-  },
+    accessGroups: ['curator@nccp']
+  }
 };

--- a/src/drivers/TokenManager.ts
+++ b/src/drivers/TokenManager.ts
@@ -4,9 +4,12 @@ import { AuthUser } from '../types/auth-user';
 /**
  * Takes a user object and generates a JWT for the user
  * @param AuthUser contains the user's id, username, firstname, lastname, and email
+ *
+ * TODO: Excess data should be removed from the token's payload (name, organization, email)
  */
 export function generateToken(user: AuthUser) {
   const payload = {
+    id: user.id,
     username: user.username,
     name: user.name,
     email: user.email,

--- a/src/interactors/AuthenticationInteractor.ts
+++ b/src/interactors/AuthenticationInteractor.ts
@@ -40,6 +40,7 @@ export async function login(
     if (authenticated) {
       const token = TokenManager.generateToken(user);
       const userResponse: UserToken = {
+        id: user.id,
         username: user.username,
         name: user.name,
         email: user.email,

--- a/src/shared/TokenEncoder.spec.ts
+++ b/src/shared/TokenEncoder.spec.ts
@@ -3,6 +3,7 @@ import { UserToken } from '../types/user-token';
 
 describe('LearningObjectDownload: TokenEncoder', () => {
   const userToken: UserToken = {
+    id: '123',
     username: 'hello',
     name: 'hello world',
     email: 'someemail@email.com',

--- a/src/types/user-token.ts
+++ b/src/types/user-token.ts
@@ -1,4 +1,5 @@
 export interface UserToken {
+  id: string;
   username: string;
   name: string;
   email: string;


### PR DESCRIPTION
This PR updates the token payload to include users' `id`. This update is in response to discussions about  structuring/restructuring routes moving forward to include users' `id` instead of `username`. 

Future work will include removing bloat from user token by removing values not necessary for auth or identification of a user.