### PR TITLE
Log the running API version on startup

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ const JSON_FILES = ['package.json', 'src/*.json', 'src/**/*.json'];
 // pull in the project TypeScript config
 const tsProject = ts.createProject('tsconfig.json');
 
-gulp.task('tsc', () => {
+gulp.task('tsc', ['assets'], () => {
   const tsResult = tsProject.src().pipe(tsProject());
   return tsResult.js.pipe(gulp.dest('dist'));
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A microservice for handling user account actions in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -158,9 +158,10 @@ function attachAuthenticatedRouters(app: express.Express) {
  * @param {Express} app [The express app to use as servers request listener]
  */
 function startHttpServer(app: express.Express) {
+  const version = require('./package.json').version;
   const server = http.createServer(app);
   server.listen(HTTP_SERVER_PORT, () => {
-    console.log(`User Service running on port ${HTTP_SERVER_PORT}`);
+    console.log(`User Service ${version} is running on port ${HTTP_SERVER_PORT}`);
   });
 }
 

--- a/src/drivers/AdminRouteHandler.ts
+++ b/src/drivers/AdminRouteHandler.ts
@@ -4,7 +4,6 @@ import { DataStore, Mailer } from '../interfaces/interfaces';
 import { UserResponseFactory } from './drivers';
 import { AdminUserInteractor } from '../interactors/AdminUserInteractor';
 import { MailerInteractor } from '../interactors/interactors';
-const version = require('../../package.json').version;
 
 export default class AdminRouteHandler {
   constructor(
@@ -30,15 +29,6 @@ export default class AdminRouteHandler {
   }
 
   private setRoutes(router: Router) {
-    // GET: returns welcome message and version number
-    // No params necessary
-    router.get('/', (req, res) => {
-      res.json({
-        version,
-        message: `Welcome to the Users Admin API v${version}`
-      });
-    });
-
     // User Routes
     router.get('/users', async (req, res) => {
       const responder = this.responseFactory.buildResponder(res);


### PR DESCRIPTION
This PR updates the startup log for the service to include the API version number. Previously, the package was being grabbed from the wrong directory. This has been updated to bundle the package into the dist and fetch it from that location.

Additionally, the welcome route for the "admin API" has been removed as it saw no use.