### PR TITLE
Ignore build-and-test workflow when merging into master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,10 +71,16 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              ignore: /master/
       - integration-test:
           requires:
             - build
+          filters:
+            branches:
+              ignore: /master/
 
   build-test-and-deploy-production:
     jobs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.4.2",
+  "version": "2.4.2-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.4.2",
+  "version": "2.4.2-2",
   "description": "A microservice for handling user account actions in the CLARK platform.",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
***Purpose***
This PR is in response to story https://app.clubhouse.io/clarkcan/story/842/only-run-non-deployment-pipeline-on-branches-that-aren-t-master

***Implementation***
Uses the ignore option for the master branch

Circle CI branch filtering docs: https://circleci.com/docs/2.0/configuration-reference/#filters-1