### PR TITLE
Update deploy script for ECS task

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-expr='.serviceArns[]|select(contains("'$ECS_SERVICE_NAME'"))|split("/")|.[1]'
-SNAME=$(aws ecs list-services --region $ECS_CLUSTER_REGION --output json --cluster $ECS_CLUSTER_NAME | jq -r $expr)
-
 # Create a new task definition for this build
 OLD_TASK_DEF=$(aws ecs describe-task-definition --region $ECS_CLUSTER_REGION --task-definition $ECS_TASK_NAME --output json)
 NEW_TASK_DEF=$(echo $OLD_TASK_DEF | jq --arg NDI $DOCKER_IMAGE '.taskDefinition.containerDefinitions[0].image=$NDI')
@@ -9,4 +6,4 @@ FINAL_TASK=$(echo $NEW_TASK_DEF | jq '.taskDefinition|{family: .family, volumes:
 
 # Update the service with the new task definition and desired count
 aws ecs register-task-definition  --region $ECS_CLUSTER_REGION --family $ECS_TASK_NAME --cli-input-json "$(echo $FINAL_TASK)"
-aws ecs update-service  --region $ECS_CLUSTER_REGION --service $SNAME --task-definition $ECS_TASK_NAME --cluster $ECS_CLUSTER_NAME
+aws ecs update-service  --region $ECS_CLUSTER_REGION --service $ECS_SERVICE_NAME --task-definition $ECS_TASK_NAME --cluster $ECS_CLUSTER_NAME

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.4.2-3",
+  "version": "2.4.2-4",
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.4.2-3",
+  "version": "2.4.2-4",
   "description": "A microservice for handling user account actions in the CLARK platform.",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
**Purpose of this PR**
Remove redundant step of finding service name. Service name doesn't need to be search for since it is provided as a variable.

**Changes**
- Remove look up step in deply script
- Swap `SNAME` for `ECS_SERVICE_NAME`