### PR TITLE
Fix user resource authentication error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "A microservice for handling user account actions in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/UserMetaRetriever/index.ts
+++ b/src/UserMetaRetriever/index.ts
@@ -18,7 +18,10 @@ import { ModuleCognitoIdentityGateway } from './gateways';
  */
 @expressServiceModule({
   expressRouter: ExpressRouterAdapter.buildRouter(),
-  providers: [{ provide: UserMetaDatastore, useClass: MongoUserMetaDatastore }, { provide: CognitoIdentityGateway, useClass: ModuleCognitoIdentityGateway }]
+  providers: [
+    { provide: UserMetaDatastore, useClass: MongoUserMetaDatastore },
+    { provide: CognitoIdentityGateway, useClass: ModuleCognitoIdentityGateway },
+  ]
 })
 export class UserMetaRetriever extends ExpressServiceModule {
   static getUserRoles = Interactor.getUserRoles;

--- a/src/app.ts
+++ b/src/app.ts
@@ -123,6 +123,7 @@ function attachPublicRouters(app: express.Express) {
       responseFactory
     )
   );
+  app.use(UserMetaRetriever.expressRouter);
 }
 /**
  * Attaches route handlers that require authentication to Express app
@@ -139,7 +140,6 @@ function attachAuthenticatedRouters(app: express.Express) {
       responseFactory
     )
   );
-  app.use(UserMetaRetriever.expressRouter);
   // TODO: Deprecate admin router and middleware in favor of default router with proper authorization logic in interactors
   app.use(enforceAdminAccess);
   app.use(


### PR DESCRIPTION
This PR moves the `UserMetaRetriever` Module to the public routes section of the middleware stack to allow visitors to CLARK to load user's profiles. 

The `UserMetaRetriever` module does contain a route to access the roles of a user as well, which should in fact be private. This is handled by the existing business logic for the functionality and with these changes still returns a `401` when an unauthenticated party makes a request.