### PR TITLE
Fix /users/tokens returns a 404

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "A microservice for handling user account actions in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/UserMetaRetriever/adapters/ExpressRouterAdapter.ts
+++ b/src/UserMetaRetriever/adapters/ExpressRouterAdapter.ts
@@ -22,10 +22,15 @@ export function buildRouter() {
  * @param {Request} req [The express request object]
  * @param {Response} res [The express response object]
  */
-async function handleGetUser(req: Request, res: Response) {
+async function handleGetUser(req: Request, res: Response, next: Function) {
   try {
-    const requester: UserToken = req['user'];
     const username: string = req.params.username;
+    if (username === 'tokens') {
+      next();
+      return;
+    }
+    const requester: UserToken = req['user'];
+    
     const user = await Interactor.getUser({ requester, username });
     res.send(user);
   } catch (e) {

--- a/src/UserMetaRetriever/adapters/ExpressRouterAdapter.ts
+++ b/src/UserMetaRetriever/adapters/ExpressRouterAdapter.ts
@@ -25,6 +25,7 @@ export function buildRouter() {
 async function handleGetUser(req: Request, res: Response, next: Function) {
   try {
     const username: string = req.params.username;
+    // FIXME: Remove this conditional once the /principal route is active
     if (username === 'tokens') {
       next();
       return;


### PR DESCRIPTION
This PR adds a temporary check to the `/users/:username` route handler to forward it's request in the middleware stack if the `username` provided is `tokens`. This is a temporary fix to prevent route collision, and will be removed once we deprecate the `/users/tokens` route in favor of `/users/:username/principal`.