### PR TITLE
Convert Chai tests to Jest and remove chai dependencies #byechai

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,23 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run-script", "serve:debug"],
       "port": 5858
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Current File",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": [
+        "${fileBasenameNoExtension}",
+        "--config",
+        "jest.config.js"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      }
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1241,12 +1241,6 @@
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
       "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
     },
-    "@types/chai": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
-      "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
-      "dev": true
-    },
     "@types/connect": {
       "version": "3.4.32",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
@@ -1915,12 +1909,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -2619,47 +2607,6 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
-    "chai": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
-      "dev": true,
-      "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
-        "type-detect": "^4.0.5"
-      }
-    },
-    "chai-http": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/chai-http/-/chai-http-4.3.0.tgz",
-      "integrity": "sha512-zFTxlN7HLMv+7+SPXZdkd5wUlK+KxH6Q7bIEMiEx0FK3zuuMqL7cwICAQ0V1+yYRozBburYuxN1qZstgHpFZQg==",
-      "dev": true,
-      "requires": {
-        "@types/chai": "4",
-        "@types/superagent": "^3.8.3",
-        "cookiejar": "^2.1.1",
-        "is-ip": "^2.0.0",
-        "methods": "^1.1.2",
-        "qs": "^6.5.1",
-        "superagent": "^3.7.0"
-      },
-      "dependencies": {
-        "@types/superagent": {
-          "version": "3.8.7",
-          "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-3.8.7.tgz",
-          "integrity": "sha512-9KhCkyXv268A2nZ1Wvu7rQWM+BmdYUVkycFeNnYrUL5Zwu7o8wPQ3wBfW59dDP+wuoxw0ww8YKgTNv8j/cgscA==",
-          "dev": true,
-          "requires": {
-            "@types/cookiejar": "*",
-            "@types/node": "*"
-          }
-        }
-      }
-    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -2674,12 +2621,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
-    },
-    "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-      "dev": true
     },
     "chokidar": {
       "version": "2.1.6",
@@ -3234,15 +3175,6 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
-    },
-    "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "^4.0.0"
-      }
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -4874,12 +4806,6 @@
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
-    "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
-      "dev": true
-    },
     "get-stdin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -6373,12 +6299,6 @@
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
-    "ip-regex": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
-      "dev": true
-    },
     "ipaddr.js": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
@@ -6549,15 +6469,6 @@
       "requires": {
         "global-dirs": "^0.1.0",
         "is-path-inside": "^1.0.0"
-      }
-    },
-    "is-ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
-      "integrity": "sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=",
-      "dev": true,
-      "requires": {
-        "ip-regex": "^2.0.0"
       }
     },
     "is-negated-glob": {
@@ -10703,12 +10614,6 @@
         }
       }
     },
-    "pathval": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
-      "dev": true
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -13260,12 +13165,6 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
-    },
-    "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
     },
     "type-fest": {
       "version": "0.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "A microservice for handling user account actions in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "devDependencies": {
     "@types/aws-sdk": "^2.7.0",
     "@types/bcrypt": "^3.0.0",
-    "@types/chai": "^4.1.5",
     "@types/cookie-parser": "^1.4.1",
     "@types/cors": "^2.8.3",
     "@types/dotenv": "^4.0.2",
@@ -66,8 +65,6 @@
     "@types/morgan": "^1.7.35",
     "@types/node": "^10.5.2",
     "@types/supertest": "^2.0.7",
-    "chai": "^4.1.2",
-    "chai-http": "^4.0.0",
     "danger": "^6.0.2",
     "gulp": "^3.9.1",
     "gulp-nodemon": "^2.2.1",

--- a/src/UserMetaRetriever/adapters/ExpressRouterAdapter.spec.ts
+++ b/src/UserMetaRetriever/adapters/ExpressRouterAdapter.spec.ts
@@ -1,3 +1,7 @@
+// set environment variables required before imports
+process.env.KEY = 'shhh im a secret';
+process.env.ISSUER = 'shhh im the issuer';
+
 import * as supertest from 'supertest';
 import * as express from 'express';
 import {
@@ -14,6 +18,7 @@ import { encodeToken } from '../../shared/TokenEncoder';
 describe('UserMetaRetriever: ExpressRouterAdapter', () => {
   let request: supertest.SuperTest<supertest.Test>;
   const validToken = encodeToken(userToken);
+
   beforeAll(() => {
     UserMetaRetriever.providers = [
       {

--- a/src/drivers/MockDriver.ts
+++ b/src/drivers/MockDriver.ts
@@ -22,8 +22,8 @@ export default class MockDriver implements DataStore {
     return;
   }
 
-  async identifierInUse(username: string): Promise<boolean> {
-    return Promise.resolve(username !== 'thisdoesntexist');
+  async identifierInUse(identifier: string): Promise<boolean> {
+    return Promise.resolve(!['thisdoesntexist', 'thisemaildoesntexist@test.com'].includes(identifier));
   }
 
   insertUser(user: User): Promise<string> {
@@ -31,11 +31,11 @@ export default class MockDriver implements DataStore {
   }
 
   async findUser(username: string): Promise<string> {
-    return Promise.resolve(MOCK_OBJECTS.USER_ID);
+    return Promise.resolve(username ? MOCK_OBJECTS.USER_ID : undefined);
   }
 
   async loadUser(id: string): Promise<any> {
-    return Promise.resolve(MOCK_OBJECTS.USER);
+    return Promise.resolve(Object.assign({}, MOCK_OBJECTS.USER));
   }
 
   async editUser(id: string, user: {}): Promise<any> {

--- a/src/drivers/MockHashDriver.ts
+++ b/src/drivers/MockHashDriver.ts
@@ -9,6 +9,6 @@ export class MockHashDriver implements HashInterface {
   }    
     
   verify(password: string, hash: string): Promise<boolean> {
-    return Promise.resolve(true);
+    return Promise.resolve(password === hash);
   }
 }

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -96,17 +96,17 @@ export default class MongoDriver implements DataStore {
   /**
    * Check if an username or email is registered to a user in the database.
    *
-   * @param {string} username the user's email
+   * @param {string} identifier the user's email address or username
    *
-   * @returns {boolean} true iff userid/pwd pair is valid
+   * @returns {boolean} true if the supplied identifier is already in use, false otherwise
    */
-  async identifierInUse(username: string): Promise<boolean> {
+  async identifierInUse(identifier: string): Promise<boolean> {
     try {
       const query: any = {};
-      if (isEmail(username)) {
-        query.email = username;
+      if (isEmail(identifier)) {
+        query.email = identifier;
       } else {
-        query.username = username;
+        query.username = identifier;
       }
       const exists = await this.db
         .collection(COLLECTIONS.USERS)

--- a/src/drivers/OTACodeManager.ts
+++ b/src/drivers/OTACodeManager.ts
@@ -44,11 +44,14 @@ export function generate(
         jwtid: otaID
       },
       (err, token) => {
+        if (err) {
+          reject(err);
+        }
         const code = token.replace(
           process.env.TOKEN_REPLACER,
           process.env.OTA_CODE_REPLACEMENT
         );
-        err ? reject(err) : resolve({ code, id: otaID });
+        resolve({ code, id: otaID });
       }
     );
   });

--- a/src/interactors/AdminUser.interactor.spec.ts
+++ b/src/interactors/AdminUser.interactor.spec.ts
@@ -1,42 +1,26 @@
 import { AdminUserInteractor } from '../interactors/AdminUserInteractor';
 import MockDriver from '../drivers/MockDriver';
 import { MOCK_OBJECTS } from '../tests/mocks';
-import { expect } from 'chai';
 const driver = new MockDriver(); // DataStore
 
 describe('fetchUsers', () => {
-  it('should return an array of users', done => {
-    return AdminUserInteractor.fetchUsers(driver, MOCK_OBJECTS.USERNAME_QUERY)
-      .then(val => {
-        expect(val).to.be.an('object');
-        done();
-      })
-      .catch(error => {
-        expect.fail();
-        done();
-      });
+  it('should return an array of users', async () => {
+    const results = await AdminUserInteractor.fetchUsers(driver, MOCK_OBJECTS.USERNAME_QUERY)
+    expect(results.total).toBeGreaterThan(0)
+    expect(results.users).toBeInstanceOf(Array);
   });
-  it('password should be undefined on user object when returned!', done => {
-    return AdminUserInteractor.fetchUsers(driver, MOCK_OBJECTS.USERNAME_QUERY)
-      .then(val => {
-        expect(val.users[0]['_password'], 'user not returned!').to.be.undefined;
-        done();
-      })
-      .catch(error => {
-        expect.fail();
-        done();
-      });
+
+  it('password should be undefined on user object when returned', async () => {
+    const result = await AdminUserInteractor.fetchUsers(driver, MOCK_OBJECTS.USERNAME_QUERY);
+    expect(
+      // @ts-ignore
+      result.users.filter(user => typeof user.password !== 'undefined' && user.password !== '').length
+    ).toBe(0);
   });
-  it('should return all users. empty query', done => {
-    return AdminUserInteractor.fetchUsers(driver, MOCK_OBJECTS.EMPTY_USERNAME_QUERY)
-      .then(val => {
-        expect(val, 'users is not an array!').to.be.a('object');
-        done();
-      })
-      .catch(error => {
-        expect.fail();
-        console.log(error);
-        done();
-      });
+
+  it('should return all users. empty query', async () => {
+    await expect(
+      AdminUserInteractor.fetchUsers(driver, MOCK_OBJECTS.EMPTY_USERNAME_QUERY)
+    ).resolves.toBeDefined();
   });
 });

--- a/src/interactors/AuthenticationInteractor.ts
+++ b/src/interactors/AuthenticationInteractor.ts
@@ -95,9 +95,17 @@ export async function register(
         ResourceErrorReason.BAD_REQUEST
       );
     }
+
     if (await datastore.identifierInUse(formattedUser.username)) {
       throw new ResourceError(
         'Username is already in use',
+        ResourceErrorReason.BAD_REQUEST
+      );
+    }
+
+    if (await datastore.identifierInUse(formattedUser.email)) {
+      throw new ResourceError(
+        'Email address is already in use',
         ResourceErrorReason.BAD_REQUEST
       );
     }

--- a/src/interactors/OTACode.interactor.spec.ts
+++ b/src/interactors/OTACode.interactor.spec.ts
@@ -2,23 +2,20 @@ import { OTACodeInteractor } from '../interactors/interactors';
 import { ACCOUNT_ACTIONS } from '../interfaces/Mailer.defaults';
 import MockDriver from '../drivers/MockDriver';
 import { MOCK_OBJECTS } from '../tests/mocks';
-const expect = require('chai').expect;
 const driver = new MockDriver(); // DataStore
 
 describe('generateOTACode', () => {
-  it('should return an OTACode', done => {
-    return OTACodeInteractor.generateOTACode(
-      driver,
-      ACCOUNT_ACTIONS.VERIFY_EMAIL,
-      MOCK_OBJECTS.EMAIL
-    )
-      .then(val => {
-        expect(val, 'Did not return OTACode').to.be.a('string');
-        done();
-      })
-      .catch(error => {
-        expect.fail();
-        done();
-      });
+  it('should return an OTACode', async () => {
+    // set required environment variable
+    process.env.OTA_CODE_SECRET = 'dont tell anybody, im a secret';
+    process.env.OTA_CODE_ISSUER = 'i am the issuer',
+
+    await expect(
+      OTACodeInteractor.generateOTACode(
+        driver,
+        ACCOUNT_ACTIONS.VERIFY_EMAIL,
+        MOCK_OBJECTS.EMAIL
+      )
+    ).resolves.toBeDefined();
   });
 });

--- a/src/interactors/authentication.interactor.spec.ts
+++ b/src/interactors/authentication.interactor.spec.ts
@@ -1,135 +1,112 @@
-import {
-  login,
-  register,
-  passwordMatch,
-  isValidUsername
-} from './AuthenticationInteractor';
 import MockDriver from '../drivers/MockDriver';
 import { MOCK_OBJECTS } from '../tests/mocks';
 import { MockHashDriver } from '../drivers/MockHashDriver';
 import { MockCognitoGateway } from '../drivers/MockCognitoGateway';
+import { AuthUser } from '../shared/typings';
+import { HttpFileAccessIdentityGateway } from '../gateways/file-access-identities/HttpFileAccessIdentityGateway';
 const driver = new MockDriver(); // DataStore
 const hasher = new MockHashDriver(); // Hasher
-const expect = require('chai').expect;
 const cognitoGateway = new MockCognitoGateway();
+
+let interactor: any;
+
 describe('AuthenticationInteractor', () => {
-  describe('#login', () => {
-    it('should pass for correct username and password', done => {
-      login(
-        driver,
-        hasher,
-        MOCK_OBJECTS.USERNAME,
-        MOCK_OBJECTS.PASSWORD,
-        cognitoGateway
-      )
-        .then(val => {
-          expect(val).to.be.a('object');
-          done();
-        })
-        .catch(error => {
-          console.log(error);
-          expect.fail();
-          done();
-        });
+  beforeAll(async () => {
+    jest.doMock('../drivers/TokenManager', () => {
+      return {
+        generateBearerToken: (user: AuthUser) => {
+          return 'somebearertokenhere'
+        }
+      }
     });
 
-    it('should fail for incorrect password', done => {
-      login(
-        driver,
-        hasher,
-        MOCK_OBJECTS.USERNAME,
-        MOCK_OBJECTS.EMPTY_STRING,
-        cognitoGateway
-      )
-        .then(val => {
-          expect.fail();
-          done();
-        })
-        .catch(error => {
-          expect(error).to.be.a('object');
-          done();
-        });
+    const mockCreateFileAccessIdentity = async (_: any) => {
+      return Promise.resolve('somefileaccessidentityhere');
+    }
+    HttpFileAccessIdentityGateway.createFileAccessIdentity = mockCreateFileAccessIdentity.bind(HttpFileAccessIdentityGateway)
+
+    interactor = await import('./AuthenticationInteractor');
+  })
+  describe('#login', () => {
+    it('should pass for correct username and password', async () => {
+      await expect(
+        interactor.login(
+          driver,
+          hasher,
+          MOCK_OBJECTS.USERNAME,
+          MOCK_OBJECTS.PASSWORD,
+          cognitoGateway
+        )
+      ).resolves.not.toThrowError();
     });
-    it('should fail for incorrect user', done => {
-      login(
-        driver,
-        hasher,
-        MOCK_OBJECTS.EMPTY_STRING,
-        MOCK_OBJECTS.PASSWORD,
-        cognitoGateway
-      )
-        .then(val => {
-          expect.fail();
-          done();
-        })
-        .catch(error => {
-          expect(error).to.be.a('object');
-          done();
-        });
+
+    it('should fail for incorrect password', async () => {
+      await expect(
+        interactor.login(
+          driver,
+          hasher,
+          MOCK_OBJECTS.USERNAME,
+          MOCK_OBJECTS.EMPTY_STRING,
+          cognitoGateway
+        )
+      ).rejects.toThrowError();
     });
-    it('should fail for empty input', done => {
-      login(
-        driver,
-        hasher,
-        MOCK_OBJECTS.EMPTY_STRING,
-        MOCK_OBJECTS.EMPTY_STRING,
-        cognitoGateway
-      )
-        .then(val => {
-          expect.fail();
-          done();
-        })
-        .catch(error => {
-          expect(error).to.be.a('object');
-          done();
-        });
+    it('should fail for incorrect user', async () => {
+      await expect(
+        interactor.login(
+          driver,
+          hasher,
+          MOCK_OBJECTS.EMPTY_STRING,
+          MOCK_OBJECTS.PASSWORD,
+          cognitoGateway
+        )
+      ).rejects.toThrowError();
+    });
+    it('should fail for empty input', async () => {
+      await expect(
+        interactor.login(
+          driver,
+          hasher,
+          MOCK_OBJECTS.EMPTY_STRING,
+          MOCK_OBJECTS.EMPTY_STRING,
+          cognitoGateway
+        )
+      ).rejects.toThrowError();
     });
   });
 });
 
 describe('AuthenticationInteractor', () => {
   describe('#register', () => {
-    it('should fail for existing username', done => {
-      login(
-        driver,
-        hasher,
-        MOCK_OBJECTS.USERNAME,
-        MOCK_OBJECTS.PASSWORD,
-        cognitoGateway
-      )
-        .then(val => {
-          return register(driver, hasher, val['user'], cognitoGateway)
-            .then(val => {
-              expect.fail();
-              done();
-            })
-            .catch(error => {
-              expect(val).to.be.a('object');
-              done();
-            });
-        })
-        .catch(error => {
-          expect.fail();
-          done();
-        });
-    });
-    it('should fail for existing email', async done => {
+    it('should fail for existing username', async () => {
       const registrationRequest = {
-        username: 'areallycoolhuman',
+        username: 'thisusernameexists',
         name: 'So Fun',
         email: 'cool@test.com',
         organization: 'towson university',
         password: 'mypassissecure',
         bio: '',
       } as any;
-      try {
-        await register(driver, hasher, registrationRequest, cognitoGateway);
-        expect.fail();
-      } catch (error) {
-        expect(error).to.be.a('error');
-        done();
-      }
+
+      await expect(
+        interactor.register(driver, hasher, registrationRequest, cognitoGateway)
+      ).rejects.toThrowError()
     });
+
+    it('should fail for existing email', async () => {
+      const registrationRequest = {
+        username: 'thisdoesntexist',
+        name: 'So Fun',
+        email: 'cool@test.com',
+        organization: 'towson university',
+        password: 'mypassissecure',
+        bio: '',
+      } as any;
+      await expect(
+        interactor.register(driver, hasher, registrationRequest, cognitoGateway)
+      ).rejects.toThrowError()
+    });
+
     it('should return a lowercased user on success', async () => {
       const registrationRequest = {
         username: 'thisDOESNTexist',
@@ -140,53 +117,41 @@ describe('AuthenticationInteractor', () => {
         bio: '',
       } as any;
 
-      try {
-        const registrationResponse =
-          await register(driver, hasher, registrationRequest, cognitoGateway);
-        expect(registrationResponse.user.username).toBe(registrationRequest.username.toLowerCase());
-      } catch (e) {
-        console.log('E', e)
-      }
+      const response = await interactor.register(driver, hasher, registrationRequest, cognitoGateway);
+      expect(response.user.username).toBe(registrationRequest.username.toLowerCase())
     });
   });
 });
 
 describe('AuthenticationInteractor', () => {
   describe('#passwordMatch', () => {
-    it('should pass for correct db, username, and password', done => {
-      passwordMatch(
-        driver,
-        hasher,
-        MOCK_OBJECTS.USERNAME,
-        MOCK_OBJECTS.PASSWORD
-      )
-        .then(val => {
-          expect(val).to.be.true;
-          done();
-        })
-        .catch(error => {
-          expect.fail();
-          done();
-        });
+    it('should pass for correct db, username, and password', async () => {
+      await expect(
+        await interactor.passwordMatch(
+          driver,
+          hasher,
+          MOCK_OBJECTS.USERNAME,
+          MOCK_OBJECTS.PASSWORD
+        )
+      ).toBeTruthy();
     });
   });
 
   describe('#isValidUsername', () => {
     it('should fail for usernames longer than 20 characters', () => {
-      expect(isValidUsername(MOCK_OBJECTS.LONG_USERNAME)).to.be.false;
+      expect(interactor.isValidUsername(MOCK_OBJECTS.LONG_USERNAME)).toBeFalsy();
     });
     it('should fail for usernames shorter than 3 characters', () => {
-      expect(isValidUsername(MOCK_OBJECTS.SHORT_USERNAME)).to.be.false;
+      expect(interactor.isValidUsername(MOCK_OBJECTS.SHORT_USERNAME)).toBeFalsy();
     });
     it('should pass for usernames shorter than 20 characters', () => {
-      expect(isValidUsername(MOCK_OBJECTS.VALID_LONG_USERNAME)).to.be.true;
+      expect(interactor.isValidUsername(MOCK_OBJECTS.VALID_LONG_USERNAME)).toBeTruthy();
     });
     it('should pass for usernames with exactly 3 characters', () => {
-      expect(isValidUsername(MOCK_OBJECTS.VALID_SHORT_USERNAME)).to.be.true;
+      expect(interactor.isValidUsername(MOCK_OBJECTS.VALID_SHORT_USERNAME)).toBeTruthy();
     });
     it('should pass for usernames with exactly 20 characters', () => {
-      expect(isValidUsername(MOCK_OBJECTS.VALID_MAX_LENGTH_USERNAME)).to.be
-        .true;
+      expect(interactor.isValidUsername(MOCK_OBJECTS.VALID_MAX_LENGTH_USERNAME)).toBeTruthy();
     });
   });
 });

--- a/src/interactors/user.interactor.spec.ts
+++ b/src/interactors/user.interactor.spec.ts
@@ -2,74 +2,45 @@ import { UserInteractor } from '../interactors/interactors';
 import { BcryptDriver } from '../drivers/BcryptDriver';
 import MockDriver from '../drivers/MockDriver';
 import { MOCK_OBJECTS } from '../tests/mocks';
-const expect = require('chai').expect;
+
 const driver = new MockDriver(); // DataStore
 const hasher = new BcryptDriver(10); // Hasher
 
 describe('searchUsers', () => {
-  it('should return an array of users', (done) => {
-    return UserInteractor.searchUsers(driver, MOCK_OBJECTS.USERNAME_QUERY)
-      .then((val) => {
-        expect(val, 'users is not an array!').to.exist;
-        done();
-      })
-      .catch((error) => {
-        expect.fail();
-        done();
-      });
+  it('should return an array of users', async ()=> {
+    await expect(
+      UserInteractor.searchUsers(driver, MOCK_OBJECTS.USERNAME_QUERY)
+    ).resolves.toBeInstanceOf(Array)
   });
 });
 
 describe('findUser', () => {
-  it('should return a user ID', (done) => {
-    return UserInteractor.findUser(driver, MOCK_OBJECTS.USERNAME)
-      .then((val) => {
-        expect(val, 'Expected user was not returned!').to.be.a('string');
-        done();
-      })
-      .catch((error) => {
-        expect.fail();
-        done();
-      });
+  it('should return a user ID', async ()=> {
+    expect(
+      typeof (await UserInteractor.findUser(driver, MOCK_OBJECTS.USERNAME))
+    ).toBe('string');
   });
-  it('should return an error message', (done) => {
+
+  it('should return an error message', async () => {
     // Here we are passing an incorrect parameter for DataStore
-    return UserInteractor.findUser(this.driver, MOCK_OBJECTS.USERNAME)
-      .then((val) => {
-        expect.fail();
-        done();
-      })
-      .catch((error) => {
-        expect(error, 'Expected user was not returned!').to.be.a('string');
-        done();
-      });
+    await expect(
+      UserInteractor.findUser(this.driver, MOCK_OBJECTS.USERNAME)
+    ).rejects.toBeDefined();
   });
 });
 
 describe('updatePassword', () => {
-  it('should return a user', (done) => {
-    return UserInteractor.updatePassword(driver, hasher, MOCK_OBJECTS.EMAIL, MOCK_OBJECTS.PASSWORD)
-      .then((val) => {
-        expect(val, 'Expected user was not returned!').to.be.a('object');
-        done();
-      })
-      .catch((error) => {
-        expect.fail();
-        done();
-      });
+  it('should return a user', async () => {
+    await expect(
+      UserInteractor.updatePassword(driver, hasher, MOCK_OBJECTS.EMAIL, MOCK_OBJECTS.PASSWORD)
+    ).resolves.toBeInstanceOf(Object);
   });
 });
 
 describe('identifierInUse', () => {
-  it('should return a boolean inUse - true', (done) => {
-    return UserInteractor.identifierInUse(driver, MOCK_OBJECTS.USERNAME)
-      .then((val) => {
-        expect(val.inUse, 'Expected isUse variable was not true').be.true;
-        done();
-      })
-      .catch((error) => {
-        expect.fail();
-        done();
-      });
+  it('should return a boolean inUse - true', async ()=> {
+    await expect(
+      UserInteractor.identifierInUse(driver, MOCK_OBJECTS.USERNAME)
+    ).resolves.toBeTruthy();
   });
 });

--- a/src/shared/TokenEncoder.spec.ts
+++ b/src/shared/TokenEncoder.spec.ts
@@ -11,8 +11,10 @@ describe('LearningObjectDownload: TokenEncoder', () => {
     organization: '',
     accessGroups: []
   };
+
   describe('encodeToken', () => {
     it('should convert object to jwt string', () => {
+      process.env.KEY = 'shhh im a secret'
       const token = encoder.encodeToken(userToken);
       expect(typeof token).toBe('string');
     });

--- a/src/shared/TokenEncoder.ts
+++ b/src/shared/TokenEncoder.ts
@@ -2,8 +2,6 @@ import 'dotenv/config';
 import * as jwt from 'jsonwebtoken';
 import { UserToken } from './typings';
 
-const SECRET_KEY = process.env.KEY;
-
 /**
  * Converts user token to jwt string
  *
@@ -13,5 +11,6 @@ const SECRET_KEY = process.env.KEY;
  * @returns {string}
  */
 export function encodeToken(userToken: UserToken): string {
+  const SECRET_KEY = process.env.KEY;
   return jwt.sign(userToken, SECRET_KEY);
 }

--- a/src/tests/mocks.ts
+++ b/src/tests/mocks.ts
@@ -24,7 +24,7 @@ export const MOCK_OBJECTS = {
     name: 'Clark Can',
     email: 'test@test.com',
     organization: 'towson university',
-    password: '',
+    password: 'Clarktesting1!',
     bio: '',
     createdAt: '',
     emailVerified: false,


### PR DESCRIPTION
This PR says "bye" to chai and converts all of the chai tests to jest. In the process of updating the tests, I cleaned up a few areas where logic or documentation doesn't make sense and updated the mocks and mock drivers with some conditional logic for testing purposes.


![](https://solifequotes.com/wp-content/uploads/2018/08/Trending-18-Funny-goodbye-memes3.jpg)
