### PR TITLE
create guideline-roles module

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,44 @@ status | body | statusText
 status | body | statusText
 ---|---|---
 `Error` | `Cannot log out at this time` |
+
+### Access Groups
+
+#### Admin
+
+- see all objects in review
+
+- edit objects in review
+
+- create revisions of released Learning Objects
+
+- assign collection Curators and Reviewers
+
+#### Editor
+
+- see all objects in review
+
+- edit objects in review
+
+- create revisions of released Learning Objects
+
+#### Reviewer@<CollectionName>
+
+- see all Learning Objects in review for a given Collection
+
+#### Curator@<CollectionName>
+
+- see all Learning Objects in review for a given Collection
+
+- assign and remove Reviewers for a given Collection
+
+
+#### Mapper
+
+- see all released Learning Objects in the system
+
+- edit the mappings of Learning Outcomes in the system. They will have access to the Mapping dashboard and the Mapping builder
+
+- add Curricular Guidelines to our system
+
+- "retire" Curricular Guidelines as new ones replace them

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.7.3-1",
+  "version": "2.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.7.3-1",
+  "version": "2.8.0",
   "description": "A microservice for handling user account actions in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -140,6 +140,7 @@ function attachAuthenticatedRouters(app: express.Express) {
       responseFactory
     )
   );
+
   // TODO: Deprecate admin router and middleware in favor of default router with proper authorization logic in interactors
   app.use(enforceAdminAccess);
   app.use(

--- a/src/drivers/AuthRouteHandler.ts
+++ b/src/drivers/AuthRouteHandler.ts
@@ -10,6 +10,7 @@ import { UserInteractor } from '../interactors/interactors';
 // tslint:disable-next-line:no-duplicate-imports
 import * as AuthInteractor from '../interactors/AuthenticationInteractor';
 import { initializePrivate } from '../collection-role/RouteHandler';
+import { initializePrivate as initializePrivateGuidelines } from '../guideline-roles/RouteHandler';
 import { reportError } from '../shared/SentryConnector';
 import { UserToken } from '../shared/typings';
 import { mapErrorToResponseData } from '../Error';
@@ -166,6 +167,7 @@ export default class AuthRouteHandler {
     });
 
     router.use(initializePrivate({ dataStore: this.dataStore }));
+    router.use(initializePrivateGuidelines({ dataStore: this.dataStore }));
   }
 
   private hasAccess(token: any, propName: string, value: any): boolean {

--- a/src/drivers/MockDriver.ts
+++ b/src/drivers/MockDriver.ts
@@ -7,6 +7,9 @@ import { UserDocument } from '../shared/typings/user-document';
 import { User } from '../shared/typings';
 
 export default class MockDriver implements DataStore {
+  fetchMappers(): Promise<any[]> {
+    throw new Error("Method not implemented.");
+  }
   fetchUserCollectionRole(params: {
     userId: string;
     collection: string;

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -357,7 +357,7 @@ export default class MongoDriver implements DataStore {
         { projection: { _id: 1, username: 1, email: 1, accessGroups: 1 }}
       )
       .toArray();
-    
+
     return users;
   }
 

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -349,6 +349,18 @@ export default class MongoDriver implements DataStore {
     return members;
   }
 
+  async fetchMappers(): Promise<any[]> {
+    const users = await this.db
+      .collection(COLLECTIONS.USERS)
+      .find<UserDocument>(
+        { accessGroups: 'mapper' },
+        { projection: { _id: 1, username: 1, email: 1, accessGroups: 1 }}
+      )
+      .toArray();
+    
+    return users;
+  }
+
   /**
    * Retrieve user document for a specifed id
    * @param params

--- a/src/guideline-roles/RouteHandler.ts
+++ b/src/guideline-roles/RouteHandler.ts
@@ -1,0 +1,85 @@
+import { DataStore } from '../interfaces/DataStore';
+import { Router, Request, Response } from 'express';
+import { mapErrorToResponseData, ResourceError, ResourceErrorReason } from '../Error';
+import { mapUserDataToUser } from '../shared/functions';
+import { isAdmin } from '../collection-role/AuthManager';
+import { requesterIsAdmin } from '../shared/AuthorizationManager';
+
+export function initializePrivate({ dataStore }: { dataStore: DataStore }) {
+    const router: Router = Router();
+
+    const ACCESS_GROUP = {
+        MAPPER: 'mapper',
+    };
+
+    const ERROR_MESSAGES = {
+        VIEW_INVALID_ACCESS: 'User does not have permission to view mapper users',
+        ADD_INVALID_ACCESS: 'User does not have permission to add mapper users',
+        REMOVE_INVALID_ACCESS: 'User does not have permission to add mapper users',
+        ALREADY_IS_MAPPER: 'Specified user is already a mapper',
+        IS_NOT_MAPPER: 'Specified user is not a mapper',
+    };
+
+    
+    const getMappers = async (req: Request, res: Response) => {
+        try {
+            const isAdmin = requesterIsAdmin(req.user);
+            if (!isAdmin) {
+                throw new ResourceError(ERROR_MESSAGES.VIEW_INVALID_ACCESS, ResourceErrorReason.INVALID_ACCESS);
+            }
+
+            let mappers = await dataStore.fetchMappers();
+            mappers = mappers.map(mapUserDataToUser);
+            res.status(200).json(mappers);
+        } catch (error) {
+            const { code, message } = mapErrorToResponseData(e);
+            res.status(code).json({ message });
+        }
+    };
+
+    const addMapper = async (req: Request, res: Response) => {
+        try {
+            requesterIsAdmin(req.user);
+            if (!isAdmin) {
+                throw new ResourceError(ERROR_MESSAGES.ADD_INVALID_ACCESS, ResourceErrorReason.INVALID_ACCESS);
+            }
+
+            const memberId = req.params.memberId;
+            const user = await dataStore.findUserById(memberId);
+            if (user.accessGroups.includes(ACCESS_GROUP.MAPPER)) {
+                throw new ResourceError(ERROR_MESSAGES.ALREADY_IS_MAPPER, ResourceErrorReason.INVALID_ACCESS);
+            }
+
+            await dataStore.assignAccessGroup(memberId, ACCESS_GROUP.MAPPER);
+            return res.sendStatus(201);
+        } catch (error) {
+            const { code, message } = mapErrorToResponseData(e);
+            res.status(code).json({ message });
+        }
+    };
+
+    const removeMapper = async (req: Request, res: Response) => {
+        try {
+            requesterIsAdmin(req.user);
+            if (!isAdmin) {
+                throw new ResourceError(ERROR_MESSAGES.REMOVE_INVALID_ACCESS, ResourceErrorReason.INVALID_ACCESS);
+            }
+
+            const memberId = req.params.memberId;
+            const user = await dataStore.findUserById(memberId);
+            if (!(user.accessGroups.includes(ACCESS_GROUP.MAPPER))) {
+                throw new ResourceError(ERROR_MESSAGES.IS_NOT_MAPPER, ResourceErrorReason.INVALID_ACCESS);
+            }
+
+            await dataStore.removeAccessGroup(memberId, ACCESS_GROUP.MAPPER);
+            return res.sendStatus(204);
+        } catch (error) {
+            const { code, message } = mapErrorToResponseData(e);
+            res.status(code).json({ message });
+        }
+    };
+
+    router.get('/guidelines/members', (req, res) => getMappers(req, res));
+    router.put('/guidelines/members/:memberId', (req, res) => addMapper(req, res));
+    router.delete('/guidelines/members/:memberId', (req, res) => removeMapper(req, res));
+}

--- a/src/interfaces/DataStore.ts
+++ b/src/interfaces/DataStore.ts
@@ -18,6 +18,7 @@ export interface DataStore extends UserStatDatastore {
   findOrganizations(query: string): Promise<any[]>;
   fetchReviewers(collection: string): Promise<any[]>;
   fetchCurators(collection: string): Promise<any[]>;
+  fetchMappers(): Promise<any[]>;
   fetchCollectionMembers(collection: string): Promise<any[]>;
   findUserById(userId: string): Promise<UserDocument>;
   fetchUserCollectionRole(params: {userId: string, collection: string}): Promise<string>;


### PR DESCRIPTION
***Purpose***
This PR adds a new module for managing guideline user roles

***Mapper***
The purpose of this story is to add an access group called mapper to the system. A mapper is a subject matter expert in a specific set of curricular guidelines and is added to system by an admin.

Their authority should include:

Ability to see all released objects in the system
Ability to edit the mappings of learning outcomes in the system. They will have access to the Mapping dashboard and the Mapping builder
Ability to add curricular guidelines to our system
Ability to "retire" curricular guidelines as new ones replace them