### PR TITLE
3853/create-secured-team-email-domain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "user-service",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.9.1",
+      "version": "2.9.2",
       "license": "ISC",
       "dependencies": {
         "@cyber4all/clark-schema": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "A microservice for handling user account actions in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/interfaces/Mailer.defaults.ts
+++ b/src/interfaces/Mailer.defaults.ts
@@ -1,5 +1,5 @@
 export enum FROM {
-  NO_REPLY = 'C.L.A.R.K. <noreply@clark.center>'
+  NO_REPLY = 'C.L.A.R.K. <noreply@secured.team>'
 }
 export enum SUBJECTS {
   VERIFY_EMAIL = 'Verify your email',


### PR DESCRIPTION
Updates the from email to come from the secured.team domain.  Completes story [3853/create-secured-team-email-domain](https://app.clubhouse.io/clarkcan/story/3853/create-secured-team-email-domain).