### PR TITLE
4304/incognito-id-is-null-in-s3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "user-service",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.9.2",
+      "version": "2.9.3",
       "license": "ISC",
       "dependencies": {
         "@cyber4all/clark-schema": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "user-service",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "A microservice for handling user account actions in the CLARK platform.",
   "main": "app.js",
   "scripts": {

--- a/src/gateways/file-access-identities/HttpFileAccessIdentityGateway.ts
+++ b/src/gateways/file-access-identities/HttpFileAccessIdentityGateway.ts
@@ -10,6 +10,7 @@ export class HttpFileAccessIdentityGateway {
       json: true,
       headers: {
         Authorization: 'Bearer',
+        'Content-Type': 'application/json',
       },
       method: 'GET',
       body: {},
@@ -41,6 +42,8 @@ export class HttpFileAccessIdentityGateway {
       }
       options.uri = FILE_ACCESS_IDENTITY_ROUTES.createFileAccessIdentity(username);
       options.headers.Authorization = `Bearer ${generateServiceToken()}`;
+
+      console.log('\n\n\nSending to LO Service', options);
       
       return await (await fetch(options.uri, options)).json();
     }

--- a/src/gateways/file-access-identities/HttpFileAccessIdentityGateway.ts
+++ b/src/gateways/file-access-identities/HttpFileAccessIdentityGateway.ts
@@ -42,8 +42,6 @@ export class HttpFileAccessIdentityGateway {
       }
       options.uri = FILE_ACCESS_IDENTITY_ROUTES.createFileAccessIdentity(username);
       options.headers.Authorization = `Bearer ${generateServiceToken()}`;
-
-      console.log('\n\n\nSending to LO Service', options);
       
       return await (await fetch(options.uri, options)).json();
     }


### PR DESCRIPTION
Updates the http request to use the content-type header and set it to json.  Completes story [4304/incognito-id-is-null-in-s3](https://app.clubhouse.io/clarkcan/story/4304/incognito-id-is-null-in-s3).